### PR TITLE
Add "Bit depth" to status line (#208)

### DIFF
--- a/oacapture/mainWindow.cc
+++ b/oacapture/mainWindow.cc
@@ -240,10 +240,12 @@ MainWindow::~MainWindow()
   delete capturedValue;
   delete fpsActualValue;
   delete fpsMaxValue;
+  delete bitDepthValue;
   delete progressBar;
   delete capturedLabel;
   delete fpsActualLabel;
   delete fpsMaxLabel;
+  delete bitDepthLabel;
   if ( state.camera ) {
     delete state.camera;
   }
@@ -1194,6 +1196,8 @@ MainWindow::createStatusBar ( void )
     tempLabel->setText ( tr ( "Temp (F)" ));
   }
   tempLabel->setFixedWidth ( 60 );
+  bitDepthLabel = new QLabel ( tr ( "Bit depth" ));
+  bitDepthLabel->setFixedWidth ( 65 );
   fpsMaxLabel = new QLabel ( tr ( "FPS (max)" ));
   fpsMaxLabel->setFixedWidth ( 65 );
   fpsActualLabel = new QLabel ( tr ( "FPS (actual)" ));
@@ -1209,6 +1213,8 @@ MainWindow::createStatusBar ( void )
 
   tempValue = new QLabel ( "" );
   tempValue->setFixedWidth ( 30 );
+  bitDepthValue = new QLabel ( "0" );
+  bitDepthValue->setFixedWidth ( 40 );
   fpsMaxValue = new QLabel ( "0" );
   fpsMaxValue->setFixedWidth ( 30 );
   fpsActualValue = new QLabel ( "0" );
@@ -1220,6 +1226,8 @@ MainWindow::createStatusBar ( void )
 
   statusLine->addPermanentWidget ( tempLabel );
   statusLine->addPermanentWidget ( tempValue );
+  statusLine->addPermanentWidget ( bitDepthLabel );
+  statusLine->addPermanentWidget ( bitDepthValue );
   statusLine->addPermanentWidget ( fpsMaxLabel );
   statusLine->addPermanentWidget ( fpsMaxValue );
   statusLine->addPermanentWidget ( fpsActualLabel );
@@ -1856,6 +1864,13 @@ MainWindow::quit ( void )
   doDisconnectFilterWheel();
   writeConfig();
   qApp->quit();
+}
+
+
+void
+MainWindow::setBitDepthValue ( int value )
+{
+  bitDepthValue->setText ( QString::number ( value ));
 }
 
 

--- a/oacapture/mainWindow.h
+++ b/oacapture/mainWindow.h
@@ -61,6 +61,7 @@ class MainWindow : public QMainWindow
     void		clearTemperature ( void );
     void		resetTemperatureLabel ( void );
     void		clearDroppedFrames ( void );
+    void		setBitDepthValue ( int );
     void		showFPSMaxValue ( int );
     void		clearFPSMaxValue ( void );
     void		setNightStyleSheet ( QWidget* );
@@ -97,6 +98,7 @@ class MainWindow : public QMainWindow
     QProgressBar*	progressBar;
     QLabel*		capturedValue;
     QLabel*		droppedValue;
+    QLabel*		bitDepthValue;
     QLabel*		fpsMaxValue;
     QLabel*		fpsActualValue;
     QStatusBar*		statusLine;
@@ -128,6 +130,7 @@ class MainWindow : public QMainWindow
     oaTimerDevice**	timerDevs;
 
     QLabel*		tempLabel;
+    QLabel*		bitDepthLabel;
     QLabel*		fpsMaxLabel;
     QLabel*		fpsActualLabel;
     QLabel*		capturedLabel;

--- a/oacapture/previewWidget.cc
+++ b/oacapture/previewWidget.cc
@@ -329,6 +329,7 @@ PreviewWidget::setVideoFramePixelFormat ( int format )
   videoFramePixelFormat = format;
   expectedSize = config.imageSizeX * config.imageSizeY *
       OA_BYTES_PER_PIXEL( videoFramePixelFormat );
+  state.mainWindow->setBitDepthValue( OA_BYTES_PER_PIXEL( format ) * 8 );
 }
 
 


### PR DESCRIPTION
An alternative to this which may be more useful in fact might be to substitute a string representation of pixel format for bit depth which in itself is still a little opaque:

eg state.mainWindow->setPixFormatValue( OA_PIX_FMT_STRING( format ) );


Happy to make this become that instead...