### PR TITLE
Add -lpthread to the link stage of oacapture and oalive binaries

### DIFF
--- a/oacapture/Makefile.am
+++ b/oacapture/Makefile.am
@@ -68,8 +68,9 @@ oacapture_LDADD = \
   $(LIBUSB_LIBS) \
   $(LIBASI2_LIBS) \
   $(LIBZWOFW_LIBS) \
-	$(LIBGPHOTO2_LIBS) \
-  $(OSX_FRAMEWORKS)
+  $(LIBGPHOTO2_LIBS) \
+  $(OSX_FRAMEWORKS) \
+  -lpthread
 
 WARNINGS = -g -O -Wall -Werror -Wpointer-arith -Wuninitialized -Wsign-compare -Wformat-security -Wno-pointer-sign $(OSX_WARNINGS)
 

--- a/oalive/Makefile.am
+++ b/oalive/Makefile.am
@@ -64,8 +64,9 @@ oalive_LDADD = \
   $(LIBUSB_LIBS) \
   $(LIBASI2_LIBS) \
   $(LIBZWOFW_LIBS) \
-	$(LIBGPHOTO2_LIBS) \
-  $(OSX_FRAMEWORKS)
+  $(LIBGPHOTO2_LIBS) \
+  $(OSX_FRAMEWORKS) \
+  -lpthread
 
 WARNINGS = -g -O -Wall -Werror -Wpointer-arith -Wuninitialized -Wsign-compare -Wformat-security -Wno-pointer-sign $(OSX_WARNINGS)
 


### PR DESCRIPTION
This apparently fixes https://github.com/openastroproject/openastro/issues/475.
It is a bit surprising that it went unnoticed. Archlinux specific ? the references to functions inside pthread in libASICamera is pretty obvious though. I would expect the build to fail without linking pthread.