### PR TITLE
Add Instructions For Contributors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,7 +90,9 @@ ui_*.h
 .libs
 .dirstamp
 *.pc
+/conftmTj6i/
 /ext/libusb/doc/doxygen.cfg
+/ext/libusb/libusb-1.0
 /ext/libusb/examples/dpfp
 /ext/libusb/examples/dpfp_threaded
 /ext/libusb/examples/fxload

--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
 # openastro
 Open Astro Project
+
+## Development Environment
+
+The following tools/libraries are required:
+
+- GNU autotools
+- libtool
+- pkg-config
+- SDL (version 1)
+- QT development tools
+- libtiff
+- libjpeg
+- libraw
+- libcfitsio3
+- libhidapi
+- libraw1394


### PR DESCRIPTION
I updated the README to include information about the development environment.
This was deduced from running `./bootstrap && ./configure` until all dependencies were met.
I noticed a couple of stray files in the tree once I was set up and ready to go so I added these to the `.gitignore`